### PR TITLE
Issue resolution

### DIFF
--- a/backend/edge-worker/package.json
+++ b/backend/edge-worker/package.json
@@ -23,7 +23,6 @@
     "miniflare": "^4.20251217.0",
     "typescript": "^5.4.2",
     "vitest": "2.1.4",
-    "vitest-environment-miniflare": "^2.14.4",
     "wrangler": "^4.28.1"
   }
 }

--- a/backend/edge-worker/vitest.config.ts
+++ b/backend/edge-worker/vitest.config.ts
@@ -2,10 +2,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'miniflare',
-    environmentOptions: {
-      compatibilityDate: '2024-01-01',
-      compatibilityFlags: ['nodejs_compat'],
-    },
+    // Use node environment since tests don't require Cloudflare Workers bindings
+    // They just call app.fetch() directly with mock context
+    environment: 'node',
   },
 });


### PR DESCRIPTION
# Pull Request

## Summary

Resolves deprecation warnings in `backend/edge-worker` tests by simplifying the Vitest environment. The tests do not require Cloudflare Workers bindings, so the `miniflare` environment was replaced with `node`.

## Changes

- Removed `vitest-environment-miniflare` dependency.
- Updated `backend/edge-worker/vitest.config.ts` to use the `node` environment.

## How to validate

1. Navigate to `backend/edge-worker`.
2. Run `npm install`.
3. Run `npm test`.
4. Verify all tests pass and no Miniflare-related deprecation warnings are displayed.

## Acceptance criteria

- [x] CI green
- [ ] No node: imports in Workers bundles
- [ ] /health returns 200 (if applicable)

## Rollback plan

- Revert this PR via GitHub; if migration files were added, follow MIGRATION_NOTES.md.

---
<a href="https://cursor.com/background-agent?bcId=bc-1012de09-cb53-4fa2-825b-80e7c8d51319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1012de09-cb53-4fa2-825b-80e7c8d51319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces Miniflare test environment with Node and removes the Miniflare Vitest dependency.
> 
> - **Tests**:
>   - Update `backend/edge-worker/vitest.config.ts` to use `environment: 'node'` and remove Miniflare-specific options.
> - **Dependencies**:
>   - Remove `vitest-environment-miniflare` from `backend/edge-worker/package.json` `devDependencies`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bb897ad1f4e22a48dea964a5ac64303745256eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->