### PR TITLE
Test: Codex auto-trigger

### DIFF
--- a/shared/schemas/tesla.ts
+++ b/shared/schemas/tesla.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+// Note: schema-only module; safe to change for CI/automation verification without runtime side effects.
 export const TeslaTelemetrySchema = z.object({
   timestamp: z.number(),
   location: z.object({


### PR DESCRIPTION
Minimal change under shared/ to verify PR auto-label -> codex:run -> Codex Run executes once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks `shared/schemas/tesla.ts` as a schema-only module to signal safe, non-functional changes for CI/automation.
> 
> - Adds a comment noting no runtime side effects in `TeslaTelemetrySchema` module
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 292357cf17814a7d77cb0ef6bb01a95ec1006cec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->