### PR TITLE
Test: Codex auto-label + run

### DIFF
--- a/shared/schemas/tesla.ts
+++ b/shared/schemas/tesla.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+// CI automation test: tiny change in runtime path to confirm autolabel -> codex:run -> Codex Run.
 export const TeslaTelemetrySchema = z.object({
   timestamp: z.number(),
   location: z.object({


### PR DESCRIPTION
Minimal change under shared/ to verify: pr-autolabel applies codex:run automatically and codex-run executes once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Purely CI/automation trigger change.
> 
> - Adds a comment to `shared/schemas/tesla.ts` to verify autolabel → codex:run execution
> - No runtime or schema modifications to `TeslaTelemetrySchema` or related types
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a600249e9a21b651c1ddeab63e5a1e62f44f6d6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->