### PR TITLE
CI: allow bot-applied codex:run label

### DIFF
--- a/.github/workflows/codex-run.yml
+++ b/.github/workflows/codex-run.yml
@@ -21,8 +21,7 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'pull_request' &&
         github.event.action == 'labeled' &&
-        github.event.label.name == 'codex:run' &&
-        github.actor != 'github-actions[bot]')
+        github.event.label.name == 'codex:run')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Fix Codex auto-triggering: pr-autolabel applies codex:run as github-actions[bot]; codex-run must allow that labeled event.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **ci: codex-run workflow trigger fix**
> 
> - Updates `codex-run.yml` to allow runs when the `codex:run` label is applied, including by `github-actions[bot]`, by removing the actor check from the `if` condition on the `pull_request` labeled event.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47df7d932d910dced76c14b525379e94420f2f7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->