### PR TITLE
ci: make security scan optional for codex:lite

### DIFF
--- a/.github/workflows/codex-run.yml
+++ b/.github/workflows/codex-run.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       verify_mode:
-        description: "Codex verification mode (lite=security scan only, full=security scan + preflight)"
+        description: "Codex verification mode (lite=no required gates, full=security scan + preflight)"
         required: false
         default: "lite"
         type: choice
@@ -41,7 +41,7 @@ jobs:
 
       # Label-controlled verification mode:
       # - codex:full => run preflight
-      # - otherwise  => lite (security scan only)
+      # - otherwise  => lite (no required gates)
       CODEX_VERIFY_MODE: >-
         ${{
           github.event_name == 'workflow_dispatch' && inputs.verify_mode ||
@@ -52,7 +52,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install ripgrep
+      - name: Install ripgrep (security scan)
+        if: ${{ env.CODEX_VERIFY_MODE == 'full' }}
         run: |
           set -euo pipefail
           if command -v rg >/dev/null 2>&1; then
@@ -94,9 +95,8 @@ jobs:
             Use the PR diff and PR description as the source of truth for what to build/fix.
 
             Verification policy:
-            - Always run: `bash scripts/security-scan.sh`
-            - If verify mode is "full", also run: `bash scripts/preflight.sh`
-            - If verify mode is "lite", DO NOT run `scripts/preflight.sh` or do heavy installs unless absolutely required to complete the requested change.
+            - If verify mode is "full": run `bash scripts/security-scan.sh` and `bash scripts/preflight.sh`.
+            - If verify mode is "lite": no required gates. Run `bash scripts/security-scan.sh` only when risk warrants (deps/auth/secrets/external APIs). Avoid heavy installs; do not run `scripts/preflight.sh` unless the PR is medium/high risk (or apply `codex:full`).
 
             Iteration policy:
             - If verification fails, implement the minimal safe fix(es) and re-run the relevant verification.
@@ -127,7 +127,7 @@ jobs:
               "",
               "Triggered by `codex:run` label.",
               "",
-              `Verify mode: \`${{ contains(github.event.pull_request.labels.*.name, 'codex:full') && 'full' || 'lite' }}\``,
+              `Verify mode: \`${process.env.CODEX_VERIFY_MODE || ""}\``,
               "",
               "### Final message",
               "```",

--- a/codex/skills/README.md
+++ b/codex/skills/README.md
@@ -4,8 +4,12 @@ This folder is intentionally small and practical. Use these as "skills" (repeata
 
 ### Quality gates
 
-- Run: `bash scripts/security-scan.sh`
-- Run: `bash scripts/preflight.sh`
+These are tools, not mandatory steps for every assignment.
+
+- **codex:lite (default)**: No required gates. Prioritize speed/cost; run targeted checks only when risk warrants (deps/auth/secrets/external APIs).
+- **codex:full**: Required gates:
+  - `bash scripts/security-scan.sh`
+  - `bash scripts/preflight.sh`
 
 ### Principles
 


### PR DESCRIPTION
## Summary

Make `scripts/security-scan.sh` optional for Codex assignments in `codex:lite` mode (platform-dev work), while keeping `codex:full` as the gated mode that runs security scan + preflight. Also skip installing ripgrep unless `codex:full` requires it.

## Changes

- `codex:lite`: no required gates; security scan is risk-based
- `codex:full`: still requires security scan + preflight
- Only install `ripgrep` when `codex:full`
- Update `codex/skills/README.md` to reflect “tools, not mandatory steps”

## How to validate

- Open a runtime PR with `codex:lite` + `codex:run`: Codex prompt should not require `scripts/security-scan.sh`, and the workflow should skip the ripgrep install step.
- Add `codex:full` and re-trigger: ripgrep install runs; prompt requires security scan + preflight.

## Mission alignment (AWhittleWandering)

Reduces CI time/cost for small platform tasks while keeping stronger gates available for higher-risk work.

## Privacy + sharing (default-private)

No changes to data sharing; avoids extra scanning unless explicitly needed.

## Agent collaboration (Cursor + Codex)

Codex focuses on platform development tasks; verification depth is controlled by labels (lite vs full).

## Acceptance criteria

- `codex:lite` no longer obligates `scripts/security-scan.sh`
- `codex:full` continues to obligate security scan + preflight
- Ripgrep install is skipped when not required

## Rollback plan

Revert commit `8f4b841`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts `codex:lite` to have no required gates while keeping `codex:full` gated with security scan + preflight.
> 
> - Updates `.github/workflows/codex-run.yml` to compute `CODEX_VERIFY_MODE`, conditionally install `ripgrep` only when `full`, and revise the Codex prompt to make `security-scan` risk-based in `lite` and required (with `preflight`) in `full`
> - PR comment now reflects computed `CODEX_VERIFY_MODE`
> - Updates `codex/skills/README.md` to clarify gates are tools, not mandatory steps; documents `lite` (no required gates) vs `full` (run `scripts/security-scan.sh` and `scripts/preflight.sh`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f4b841a4cae3a39a2d7ff1c452873bc8404804f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->