### PR TITLE
ci: keep codex labels enforced

### DIFF
--- a/.github/workflows/pr-autolabel.yml
+++ b/.github/workflows/pr-autolabel.yml
@@ -2,7 +2,10 @@ name: PR Auto-label (Codex policy)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    # Include label changes so policy labels (e.g. codex:autonomous) are re-applied
+    # if someone removes them manually. This workflow only ADDS missing labels (never removes),
+    # so it converges quickly and does not loop indefinitely.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Intent

Keep Codex policy labels (e.g. `codex:autonomous`, and runtime labels when applicable) **live** even if labels are manually removed.

## Change

- Update `pr-autolabel` workflow triggers to also run on `pull_request` `labeled` and `unlabeled` events.
- The workflow remains add-only (never removes labels), so it converges quickly and avoids churn.

## Verification

- On any PR, remove `codex:autonomous` and observe it is re-added by `PR Auto-label (Codex policy)`.

## Rollback

Revert commit `c0354e6`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Keeps Codex policy labels continually enforced by reacting to label changes.
> 
> - Update `on.pull_request.types` in `.github/workflows/pr-autolabel.yml` to include `labeled` and `unlabeled`
> - Add comments clarifying add-only behavior to avoid loops and ensure quick convergence
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0354e696015f9011f127661bb4ec02a3e35bc01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->