### PR TITLE
fix(frontend,api): prevent blank screen + allow Pages CORS

### DIFF
--- a/backend/edge-worker/src/index.ts
+++ b/backend/edge-worker/src/index.ts
@@ -41,6 +41,10 @@ app.use('*', analyticsLogger);
 app.use('*', rateLimit);
 app.use('*', errorHandler);
 
+// Ensure preflight requests always get a sane response.
+// CORS headers are added by `corsMiddleware` above (for allowed origins).
+app.options('*', (c) => c.body(null, 204));
+
 // In-memory latency ring buffer (lightweight; resets on deploy)
 const LAT_SAMPLES_MAX = 200;
 const latencySamples: number[] = [];
@@ -145,7 +149,7 @@ app.get('/api/v1/config', async (c) => {
   const mapboxToken = c.env?.MAPBOX_API_TOKEN || null;
 
   return c.json({
-    appName: 'Tesla Road Trip Tracker',
+    appName: 'A Whittle Wandering',
     apiVersion: '3.0.0',
     mode,
     apiBaseUrl,

--- a/backend/edge-worker/src/middleware/cors.ts
+++ b/backend/edge-worker/src/middleware/cors.ts
@@ -30,8 +30,9 @@ export const corsMiddleware = cors({
     return isAllowedOrigin(origin) ? origin : null;
   },
   allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowHeaders: ['Content-Type', 'Authorization', 'X-Client-ID'],
-  credentials: true
+  allowHeaders: ['Content-Type', 'Authorization', 'X-Client-ID', 'Accept'],
+  credentials: true,
+  maxAge: 86400
 });
 
 export async function securityHeaders(c: Context, next: Next) {

--- a/frontend/src/lib/api-config.ts
+++ b/frontend/src/lib/api-config.ts
@@ -2,12 +2,19 @@
 // Handles all API endpoints and provides consistent error handling
 
 const getApiBaseUrl = () => {
-  // Highest precedence: explicit env override (Vite exposes import.meta.env)
-  // Support both Vite style and fallback process.env for tests
-  const override = (import.meta as any).env?.VITE_API_BASE_URL || (process.env as any).VITE_API_BASE_URL;
-  if (override) return override;
-  if (process.env.NODE_ENV === 'development') return 'http://localhost:8787';
-  return 'https://api.awhittlewandering.com';
+  // Vite exposes `import.meta.env` at build time. Do NOT touch `process` in the browser;
+  // referencing it can throw and crash app bootstrap (blank screen).
+  const env = ((import.meta as any)?.env || {}) as Record<string, unknown>;
+
+  // Highest precedence: explicit env override
+  const override = (env.VITE_API_BASE_URL || env.VITE_BACKEND_URL) as string | undefined;
+  if (typeof override === 'string' && override.trim()) return override.trim();
+
+  // Local dev
+  if (env.DEV === true) return 'http://localhost:8787';
+
+  // Production default (Cloudflare Worker). Keep this aligned with deployments.
+  return 'https://awhittlewandering-api.kd8jc7v8cd.workers.dev';
 };
 
 export const API_CONFIG = {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,11 +1,19 @@
 // API configuration for A Whittle Wandering
+const getApiBaseUrl = () => {
+  const env = ((import.meta as any)?.env || {}) as Record<string, unknown>;
+  const override = (env.VITE_API_BASE_URL || env.VITE_BACKEND_URL) as string | undefined;
+  if (typeof override === 'string' && override.trim()) return override.trim();
+  if (env.DEV === true) return 'http://localhost:8787';
+  return 'https://awhittlewandering-api.kd8jc7v8cd.workers.dev';
+};
+
 export const API_CONFIG = {
-  BASE_URL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8787',
+  BASE_URL: getApiBaseUrl(),
   ENDPOINTS: {
-    HEALTH: '/health',
+    HEALTH: '/api/v1/health',
     TELEMETRY: '/api/v1/telemetry',
-    TRIP_STATUS: '/api/v1/trip/status',
-  }
+    TRIP_STATUS: '/api/v1/trip-status',
+  },
 } as const;
 
 // Make API calls to our deployed backend


### PR DESCRIPTION
## Summary
- Fixes frontend API base resolution so it never touches `process` in the browser (prevents runtime crash/blank screen when `VITE_API_BASE_URL` is unset).
- Defaults production API base to the Workers API deployment.
- Improves backend CORS preflight handling (explicit OPTIONS 204 + cacheable preflight + allow `Accept`).
- Aligns `/api/v1/config` `appName` with A Whittle Wandering.

## Evidence (from QA)
- Pages deployment was making requests to `.../undefined/api/v1/config` and crashing with a JS runtime error.
- Browser requests to the Workers API were blocked by CORS (missing ACAO on preflight).

## Test plan
- Frontend: load `https://awhittlewandering.pages.dev` and confirm no blank screen; verify network calls go to `https://awhittlewandering-api.kd8jc7v8cd.workers.dev/api/v1/*`.
- Backend: from a browser origin `https://awhittlewandering.pages.dev`, verify `GET /api/v1/unified-data` succeeds without CORS errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Frontend API base resolution**: Replace `process` usage with `import.meta.env` and add sensible defaults (local dev and Workers URL) in `api-config.ts` and `api.ts` to prevent blank screen when env vars are unset.
> - **CORS improvements**: Add explicit `OPTIONS * -> 204` handler; include `Accept` in `allowHeaders`; enable `maxAge` for cacheable preflight in `middleware/cors.ts`.
> - **Endpoint alignment**: Update frontend endpoints to `'/api/v1/health'` and `'/api/v1/trip-status'` in `api.ts`.
> - **Config naming**: Change `appName` in `GET /api/v1/config` to `"A Whittle Wandering"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8545636009848085347aad5151588a5e91a1b5ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->