### PR TITLE
Charging recommendation setter

### DIFF
--- a/frontend/src/components/EnhancedTeslaApp.tsx
+++ b/frontend/src/components/EnhancedTeslaApp.tsx
@@ -51,7 +51,7 @@ export const EnhancedTeslaApp: React.FC<EnhancedTeslaAppProps> = ({
   };
 
   const handleChargingRecommendation = (recommendation: SmartChargingRecommendation) => {
-    setChargingRecommendations(prev => [...prev, recommendation]);
+    _setChargingRecommendations(prev => [...prev, recommendation]);
     console.warn('⚡ New charging recommendation:', recommendation);
   };
 


### PR DESCRIPTION
# Pull Request

## Summary

Fixes a runtime error in the `handleChargingRecommendation` handler by correcting the state setter name from `setChargingRecommendations` to `_setChargingRecommendations`, enabling the charging recommendation feature to function correctly.

## Changes

- Corrected the setter name in `handleChargingRecommendation` within `EnhancedTeslaApp.tsx`.

## How to validate

1.  Run `npm ci`
2.  Run `npm -w frontend run lint`
3.  Run `npm -w frontend test`
4.  Run `npx tsc -p frontend/tsconfig.json --noEmit`

## Acceptance criteria

- [ ] CI green
- [ ] No node: imports in Workers bundles
- [ ] /health returns 200 (if applicable)

## Rollback plan

Revert this PR via GitHub (`git revert 3bdb3bc`); if migration files were added, follow MIGRATION_NOTES.md.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa7ac0e7-0afd-4e86-b9f2-8ba830cd3ba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa7ac0e7-0afd-4e86-b9f2-8ba830cd3ba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

