### PR TITLE
fix: enable workers_dev for production and fix API URLs

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -90,7 +90,7 @@ jobs:
           case "$ENV" in
             production)
               echo "worker_name=awhittlewandering-api" >> $GITHUB_OUTPUT
-              echo "health_url=https://api.awhittlewandering.com/api/v1/health" >> $GITHUB_OUTPUT
+              echo "health_url=https://awhittlewandering-api.workers.dev/api/v1/health" >> $GITHUB_OUTPUT
               ;;
             staging)
               echo "worker_name=awhittlewandering-api-staging" >> $GITHUB_OUTPUT

--- a/backend/edge-worker/wrangler.toml
+++ b/backend/edge-worker/wrangler.toml
@@ -160,6 +160,7 @@ binding = "AI"
 
 [env.production]
 name = "awhittlewandering-api"
+workers_dev = true
 
 # Production environment variables - ZERO FAILURE API MANAGEMENT
 [env.production.vars]

--- a/frontend/src/lib/api-config.ts
+++ b/frontend/src/lib/api-config.ts
@@ -9,8 +9,8 @@ const getApiBaseUrl = (): string => {
   // Dev mode (Vite sets this)
   if (viteEnv?.DEV) return 'http://localhost:8787';
 
-  // Production: use the deployed backend worker URL
-  return 'https://api.awhittlewandering.com';
+  // Production: use the workers.dev URL until custom domain DNS is configured
+  return 'https://awhittlewandering-api.workers.dev';
 };
 
 export const API_CONFIG = {


### PR DESCRIPTION
## Summary
- Enable `workers_dev = true` in production wrangler config so the backend is accessible at `awhittlewandering-api.workers.dev`
- Update frontend production API URL from `api.awhittlewandering.com` (no DNS records) to `awhittlewandering-api.workers.dev`
- Update deploy-backend health check URL to use workers.dev URL

## Context
The custom domain `api.awhittlewandering.com` has no DNS records configured in Cloudflare. This caused every post-deploy verification to fail since Feb 6, creating 11 duplicate issues (#178-#196). The backend worker IS deployed successfully, but is unreachable because:
1. The custom domain has no DNS
2. The production env didn't enable `workers_dev`, so the `*.workers.dev` fallback URL didn't work either

## Test plan
- [ ] CI passes (build, tests, typecheck)
- [ ] Post-deploy verification should now succeed with workers.dev URLs
- [ ] Frontend can reach backend API at workers.dev URL

Resolves #178 #179 #181 #186 #187 #189 #190 #192 #193 #195 #196

https://claude.ai/code/session_01C2v1DFVxxQAJSe14vRykei