### PR TITLE
fix(ci): install deps in deploy-backend deploy job

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -128,7 +128,6 @@ jobs:
       - name: Run Backend Tests
         run: |
           cd ${{ env.WORKER_DIR }}
-          npm ci || npm install
           npm test || echo "No tests configured"
 
       - name: Type Check
@@ -152,10 +151,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Dependencies
-        run: |
-          npm ci || npm install
-          cd shared && npm ci || npm install
-          cd ../${{ env.WORKER_DIR }} && npm ci || npm install
+        run: npm ci || npm install
 
       - name: Build Shared Schemas
         run: |
@@ -198,6 +194,9 @@ jobs:
         with:
           name: worker-build-${{ needs.setup.outputs.environment }}
           path: ${{ env.WORKER_DIR }}/dist/
+
+      - name: Install Dependencies
+        run: npm ci || npm install
 
       - name: Install Wrangler
         run: npm install -g wrangler@3


### PR DESCRIPTION
## Summary
- Add missing `npm ci || npm install` step to the `deploy` job in `deploy-backend.yml`
- The deploy job only installed wrangler globally but not project dependencies, so wrangler's bundler couldn't resolve `hono` and `zod` (marked `--external` in esbuild)
- Also removes redundant per-workspace `npm install` commands from the `build` and `test` jobs (same fix applied to `ci-preflight.yml` in PR #194)

## Root cause
The esbuild command uses `--external:hono --external:zod`, leaving these as unresolved imports in `dist/index.js`. When the deploy job runs `wrangler deploy`, wrangler's bundler tries to resolve them but can't find them since `node_modules` wasn't installed.

## Test plan
- [ ] CI preflight passes (build, tests, migrations, etc.)
- [ ] The next production deploy via `deploy-backend.yml` should succeed
- [ ] Post-deploy verification should pass (workers.dev URL accessible)

Resolves #198 #199

https://claude.ai/code/session_01C2v1DFVxxQAJSe14vRykei