### PR TITLE
fix: use Custom Domain for api.awhittlewandering.com

### DIFF
--- a/backend/edge-worker/wrangler.toml
+++ b/backend/edge-worker/wrangler.toml
@@ -226,7 +226,7 @@ binding = "TELEMETRY_ANALYTICS"
 # max_batch_size = 10
 # max_batch_timeout = 5
 
-# Production domain routing
+# Production custom domain — Cloudflare auto-creates DNS records + SSL certs
 [[env.production.routes]]
-pattern = "api.awhittlewandering.com/*"
-zone_name = "awhittlewandering.com"
+pattern = "api.awhittlewandering.com"
+custom_domain = true


### PR DESCRIPTION
## Summary
- Switch production route from a **Route** (`zone_name`) to a **Custom Domain** (`custom_domain = true`)
- Routes require DNS records to already exist — Custom Domains auto-create them

## Before (broken)
```toml
[[env.production.routes]]
pattern = "api.awhittlewandering.com/*"
zone_name = "awhittlewandering.com"
```
This requires manually creating a DNS record for `api.awhittlewandering.com` first. Since no DNS record exists, the route is unreachable.

## After (self-healing)
```toml
[[env.production.routes]]
pattern = "api.awhittlewandering.com"
custom_domain = true
```
Cloudflare automatically creates DNS records and issues SSL certificates on `wrangler deploy --env production`. Per [Custom Domains docs](https://developers.cloudflare.com/workers/configuration/routing/custom-domains/).

## Test plan
- [ ] CI passes
- [ ] After merge, the Deploy Backend workflow should succeed and auto-configure DNS
- [ ] `api.awhittlewandering.com` should resolve and return 200 on `/api/v1/health`

https://claude.ai/code/session_01C2v1DFVxxQAJSe14vRykei