### PR TITLE
fix: disable R2 binding in production until enabled in dashboard

### DIFF
--- a/backend/edge-worker/wrangler.toml
+++ b/backend/edge-worker/wrangler.toml
@@ -197,10 +197,12 @@ binding = "TESLA_DB"
 database_name = "tesla-journey-tracker"
 database_id = "889d864a-966d-4e8a-a3cd-bc60abf23688"
 
-# Production R2 bucket
-[[env.production.r2_buckets]]
-binding = "MEDIA_BUCKET"
-bucket_name = "awhittlewandering-media"
+# Production R2 bucket — disabled until R2 is enabled in Cloudflare dashboard
+# Enable R2 at: https://dash.cloudflare.com → R2 Object Storage → Get Started
+# Then uncomment these lines:
+# [[env.production.r2_buckets]]
+# binding = "MEDIA_BUCKET"
+# bucket_name = "awhittlewandering-media"
 
 # Production KV for auth tokens
 [[env.production.kv_namespaces]]


### PR DESCRIPTION
## Summary
Comment out the R2 bucket binding in `[env.production]` to unblock `wrangler deploy --env production`.

## Root cause
The Cloudflare account doesn't have R2 enabled. Wrangler deploy fails with:
```
R2 binding error for bucket 'awhittlewandering-media': Please enable R2 through the Cloudflare Dashboard. [code: 10136]
```

## Why this is safe
The `MEDIA_BUCKET` binding is already optional in all code paths:
- `c.env?.MEDIA_BUCKET` (optional chaining in `media.ts`)
- `if (c.env?.MEDIA_BUCKET)` guard in `health.ts`
- `MEDIA_BUCKET?: R2Bucket` (optional type in `env.ts`)

## To re-enable
1. Enable R2 in the Cloudflare dashboard
2. Uncomment the R2 binding in wrangler.toml

## Test plan
- [ ] CI passes
- [ ] Deploy Backend workflow succeeds after merge

https://claude.ai/code/session_01C2v1DFVxxQAJSe14vRykei