### PR TITLE
fix: reduce cron triggers to stay within account limit

### DIFF
--- a/backend/edge-worker/wrangler.toml
+++ b/backend/edge-worker/wrangler.toml
@@ -4,13 +4,12 @@ compatibility_date = "2023-10-30"
 workers_dev = true
 
 # Cron Triggers for Automated Data Ingestion
+# Free plan limit: 5 cron triggers per account
 [triggers]
 crons = [
-  "*/15 6-23 * * *",  # Quick state updates (reduced from every 5m to 15m)
   "*/30 * * * *",     # Full sync every 30 minutes
   "0 2 * * *",        # Historical backfill at 2 AM daily
-  "5 * * * *",        # Data quality check hourly (offset minute 5)
-  "10 */6 * * *"      # AI/ML processing every 6 hours (offset minute 10)
+  "5 * * * *"         # Data quality check hourly (offset minute 5)
 ]
 
 # Environment Variables - ZERO FAILURE API MANAGEMENT


### PR DESCRIPTION
## Summary
Reduce cron triggers from 5 to 3 to stay within the Cloudflare account limit.

## Error
```
You have exceeded the limit of 5 cron triggers. [code: 10072]
```

## Changes
Kept the 3 essential triggers:
- `*/30 * * * *` — Full data sync (covers quick state updates too)
- `0 2 * * *` — Historical backfill daily
- `5 * * * *` — Data quality check hourly

Removed:
- `*/15 6-23 * * *` — Quick state updates (redundant with 30-min full sync)
- `10 */6 * * *` — AI/ML processing (can be triggered manually)

## Test plan
- [ ] CI passes
- [ ] Deploy Backend succeeds after merge (no more cron limit error)

https://claude.ai/code/session_01C2v1DFVxxQAJSe14vRykei