### PR TITLE
auto: Create ETL import script for Tessie data

### DIFF
--- a/src/utils/import-tessie-data.ts
+++ b/src/utils/import-tessie-data.ts
@@ -1,0 +1,22 @@
+import { readFile } from 'fs/promises';
+import { populateCanonicalTables } from '../db/populate-canonical-tables';
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error('Usage: ts-node src/utils/import-tessie-data.ts <path-to-tessie-json>');
+    process.exit(1);
+  }
+  const [filePath] = args;
+  try {
+    const raw = await readFile(filePath, 'utf8');
+    const data = JSON.parse(raw);
+    await populateCanonicalTables(data);
+    console.log('Import completed successfully');
+  } catch (err) {
+    console.error('Error importing Tessie data:', err);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Auto-generated by Coding Agent
**Task:** Create ETL import script for Tessie data
**Objective:** Create src/utils/import-tessie-data.ts that reads raw Tessie data (from source) and invokes populate-canonical-tables to load into DB.
**Reasoning:** Need a dedicated script to orchestrate the ETL migration from raw data to canonical tables.
### Files Changed
- `src/utils/import-tessie-data.ts` (create)
---
*Generated by local-devops-ai coding agent*