### PR TITLE
auto: Implement ETL script to populate canonical tables from raw Tessie data (simplified)

### DIFF
--- a/src/utils/populate-canonical-tables.ts
+++ b/src/utils/populate-canonical-tables.ts
@@ -1,0 +1,58 @@
+import { Logger } from '../core/logger';
+
+interface RawTessieData {
+  id: string;
+  rawData: Record<string, unknown>;
+}
+
+interface CanonicalTableEntry {
+  id: string;
+  processedData: Record<string, unknown>;
+}
+
+export class CanonicalTablePopulator {
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  async populateCanonicalTables(rawData: RawTessieData[]): Promise<CanonicalTableEntry[]> {
+    try {
+      this.logger.info('Starting canonical table population');
+
+      // TODO: Implement data transformation logic
+      const canonicalEntries: CanonicalTableEntry[] = rawData.map(entry => ({
+        id: entry.id,
+        processedData: this.transformRawData(entry.rawData)
+      }));
+
+      // TODO: Implement database insertion logic
+      await this.insertCanonicalEntries(canonicalEntries);
+
+      this.logger.info('Populated ${canonicalEntries.length} canonical table entries');
+      return canonicalEntries;
+    } catch (error) {
+      this.logger.error('Error populating canonical tables', error);
+      throw new Error('Failed to populate canonical tables');
+    }
+  }
+
+  private transformRawData(rawData: Record<string, unknown>): Record<string, unknown> {
+    // TODO: Implement complex data transformation rules
+    return {
+      ...rawData,
+      processedAt: new Date().toISOString()
+    };
+  }
+
+  private async insertCanonicalEntries(entries: CanonicalTableEntry[]): Promise<void> {
+    // TODO: Implement actual database insertion
+    // This is a placeholder for database interaction
+    console.log('Inserting ${entries.length} entries');
+  }
+}
+
+export const createCanonicalTablePopulator = (logger: Logger): CanonicalTablePopulator => {
+  return new CanonicalTablePopulator(logger);
+};


### PR DESCRIPTION
## Auto-generated by Coding Agent
**Task:** Implement ETL script to populate canonical tables from raw Tessie data (simplified)
**Objective:** Create a minimal implementation file at src/utils/populate-canonical-tables.ts for: Implement ETL script to populate canonical tables from raw Tessie data.

Requirements:
- Export the main function/class
- Include TypeScript types
- Add TODO comments for complex logic
- Must compile without errors

Output exactly: [{"path":"src/utils/populate-canonical-tables.ts","content":"<complete file>","action":"create"}]
**Reasoning:** The existing file is a dry-run implementation; we need to convert it to a functional ETL migration that actually populates the canonical tables, which is required to meet the drives and charges count targets.
### Files Changed
- `src/utils/populate-canonical-tables.ts` (create)
---
*Generated by local-devops-ai coding agent*