### PR TITLE
auto: Create H3 privacy middleware to redact IP and user agent

### DIFF
--- a/src/middleware/privacy.ts
+++ b/src/middleware/privacy.ts
@@ -1,0 +1,51 @@
+import crypto from 'crypto';
+import { Request, Response, NextFunction } from 'express';
+
+interface PrivacyConfig {
+  saltKey?: string;
+  hashIp?: boolean;
+  redactUserAgent?: boolean;
+}
+
+const DEFAULT_CONFIG: PrivacyConfig = {
+  saltKey: process.env.PRIVACY_SALT || 'default-privacy-salt',
+  hashIp: true,
+  redactUserAgent: true
+};
+
+function hashValue(value: string, salt: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(`${value}${salt}`)
+    .digest('hex');
+}
+
+function redactUserAgent(userAgent?: string): string {
+  return userAgent ? '[REDACTED]' : '';
+}
+
+export function privacyMiddleware(config: PrivacyConfig = {}) {
+  const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (mergedConfig.hashIp && req.ip) {
+      req.privacyIp = hashValue(req.ip, mergedConfig.saltKey!);
+    }
+
+    if (mergedConfig.redactUserAgent && req.get('User-Agent')) {
+      req.privacyUserAgent = redactUserAgent(req.get('User-Agent'));
+    }
+
+    next();
+  };
+}
+
+// Extend Request interface to include privacy fields
+declare global {
+  namespace Express {
+    interface Request {
+      privacyIp?: string;
+      privacyUserAgent?: string;
+    }
+  }
+}


### PR DESCRIPTION
## Auto-generated by Coding Agent
**Task:** Create H3 privacy middleware to redact IP and user agent
**Objective:** Create src/middleware/privacy.ts that redacts or hashes IP address and user-agent before logging, using crypto to hash IP with salt.
**Reasoning:** Needed to prevent PII storage in logs; unblocks request logger update.
### Files Changed
- `src/middleware/privacy.ts` (create)
---
*Generated by local-devops-ai coding agent*