### PR TITLE
auto: Update states_visited and journey totals based on migrated data

### DIFF
--- a/src/utils/update-journey-totals.ts
+++ b/src/utils/update-journey-totals.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+interface Env {
+  DB: D1Database;
+}
+
+/**
+ * Updates aggregate journey metrics (total distance, total energy) in journey_stats.
+ * Reads sum of distance from trips and sum of energy_charged from charges.
+ */
+export async function updateJourneyTotals(env: Env): Promise<void> {
+  const { DB } = env;
+
+  // Total distance from trips
+  const distanceResult = await DB.prepare(
+    `SELECT COALESCE(SUM(distance), 0) AS total_distance FROM trips WHERE distance IS NOT NULL`
+  ).first();
+
+  // Total energy from charges
+  const energyResult = await DB.prepare(
+    `SELECT COALESCE(SUM(energy_charged), 0) AS total_energy FROM charges WHERE energy_charged IS NOT NULL`
+  ).first();
+
+  // Validate results
+  const DistanceRow = z.object({ total_distance: z.number() });
+  const EnergyRow = z.object({ total_energy: z.number() });
+  const distanceRow = DistanceRow.parse(distanceResult);
+  const energyRow = EnergyRow.parse(energyResult);
+
+  const totalDistance = Number(distanceRow.total_distance);
+  const totalEnergy = Number(energyRow.total_energy);
+
+  // Upsert into journey_stats as a JSON object
+  const stats = { total_distance: totalDistance, total_energy: totalEnergy };
+
+  await DB.prepare(
+    `
+    INSERT INTO journey_stats (key, value, updated_at)
+    VALUES ('journey_totals', ?, DATETIME('now'))
+    ON CONFLICT(key) DO UPDATE SET
+      value = excluded.value,
+      updated_at = excluded.updated_at
+    `
+  )
+    .bind(JSON.stringify(stats))
+    .run();
+}

--- a/src/utils/update-states-visited.ts
+++ b/src/utils/update-states-visited.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+interface Env {
+  DB: D1Database;
+}
+
+/**
+ * Updates the list of visited states in the journey_stats table.
+ * Reads distinct states from the trips table and persists them as JSON.
+ */
+export async function updateStatesVisited(env: Env): Promise<void> {
+  const { DB } = env;
+
+  // Fetch distinct non-null states from trips
+  const statesResult = await DB.prepare(
+    `SELECT DISTINCT state FROM trips WHERE state IS NOT NULL AND state <> ''`
+  ).all();
+
+  // Validate rows
+  const StatesArray = z.array(z.object({ state: z.string().nullable() }));
+  const statesRows = StatesArray.parse(statesResult.results);
+
+  // Extract string values, filter out nulls/empty
+  const states = statesRows
+    .map((row) => row.state)
+    .filter((s): s is string => s !== null && s !== '')
+    .sort(); // optional: sort for consistency
+
+  // Upsert into journey_stats
+  await DB.prepare(
+    `
+    INSERT INTO journey_stats (key, value, updated_at)
+    VALUES ('states_visited', ?, DATETIME('now'))
+    ON CONFLICT(key) DO UPDATE SET
+      value = excluded.value,
+      updated_at = excluded.updated_at
+    `
+  )
+    .bind(JSON.stringify(states))
+    .run();
+}


### PR DESCRIPTION
## Auto-generated by Coding Agent
**Task:** Update states_visited and journey totals based on migrated data
**Objective:** Create src/utils/update-states-visited.ts and src/utils/update-journey-totals.ts to compute and persist visited states and aggregate journey metrics (distance, energy) from the migrated trip and charge data.
**Stack:** cf-workers / javascript / wrangler (esm)
**Reasoning:** After trips and charges are in canonical tables, we need to derive auxiliary analytics tables (states_visited) and summary fields (journey totals) for dashboard and API consumption.
### Files Changed
- `src/utils/update-states-visited.ts` (create)
- `src/utils/update-journey-totals.ts` (create)
---
*Generated by local-devops-ai coding agent*